### PR TITLE
feat(config): switched from os module usage to pathlib

### DIFF
--- a/src/docbinder_oss/helpers/config.py
+++ b/src/docbinder_oss/helpers/config.py
@@ -1,7 +1,6 @@
 import logging
-import os
+from pathlib import Path  
 from typing import List
-
 import typer
 import yaml
 from pydantic import BaseModel, ValidationError
@@ -10,23 +9,23 @@ from docbinder_oss.services import ServiceUnion, get_provider_registry
 
 logger = logging.getLogger(__name__)
 
-CONFIG_PATH = os.path.expanduser("~/.config/docbinder/config.yaml")
-
+CONFIG_PATH = Path("~/.config/docbinder/config.yaml").expanduser()
 
 class Config(BaseModel):
     """Main configuration model that holds a list of all provider configs."""
-
     providers: List[ServiceUnion]
 
 
 def load_config() -> Config:
-    if not os.path.exists(CONFIG_PATH):
+    if not CONFIG_PATH.exists():
         typer.echo(
             f"Config file not found at {CONFIG_PATH}. Please run 'docbinder setup' first."
         )
         raise typer.Exit(code=1)
+
     with open(CONFIG_PATH, "r") as f:
         config_data = yaml.safe_load(f)
+
     provider_registry = get_provider_registry()
     config_to_add = []
     for config in config_data.get("providers", []):
@@ -45,7 +44,8 @@ def load_config() -> Config:
 
 
 def save_config(config: Config):
-    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
     with open(CONFIG_PATH, "w") as f:
         yaml.dump(config.model_dump(), f, default_flow_style=False)
     typer.echo(f"Config saved to {CONFIG_PATH}")


### PR DESCRIPTION
# Pull Request

## Description
Based on https://github.com/SnappyLab/DocBinder-OSS/issues/9 : I changed any reference to the python os module to pathlib instead. 

Note : Seeing as this is a swap from one default module to another default one, there's no need to update any module dependency. It was already available from >Python3.11 

## Type of change
- [X] New feature

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

Tests results : 

<details>

```
|   py313: OK (31.48=setup[14.95]+cmd[16.54] seconds)
|   congratulations :) (32.87 seconds)
|   py311: OK (31.44=setup[17.98]+cmd[13.46] seconds)
|   congratulations :) (32.69 seconds)
|   py312: OK (32.55=setup[16.31]+cmd[16.24] seconds)
|   congratulations :) (34.09 seconds)
```

</details>

Feel free to come back to me if the pull request isn't following guidelines. 